### PR TITLE
Arreglo del gradient checkpointing

### DIFF
--- a/config/experiments/salamandra-2b-bench/llama3.2-3b-bench.yaml
+++ b/config/experiments/salamandra-2b-bench/llama3.2-3b-bench.yaml
@@ -1,0 +1,70 @@
+task: "clm_training"
+experiment_name: "llama3.2-3b-bench-continual"
+verbose_level: 3
+
+# Training data
+dataset:
+  source: "local"
+  nameOrPath: "/workspace/data/tokenized/dc6-llama-3b"
+  #nameOrPath: "/workspace/data/tokenized/anonymized-va-bench"
+  format: "hf"
+
+# Output dir
+output_dir: "output/llama3_2-3b-bench/"
+precision: "bf16-true"
+# Model
+model_name: "meta-llama/Llama-3.2-3B"
+#"meta-llama/Llama-3.2-3B"
+
+# Model precision
+static_graph: false
+
+# Training parameters
+number_epochs: 1
+batch_size: 6
+gradient_accumulation: true
+gradient_accumulation_steps: 4
+grad_clip: 1.0
+
+# Optimizer parameters
+lr: 0.00002      
+lr_decay: true
+weight_decay: 0.01
+beta1: 0.9
+beta2: 0.999
+
+
+# Scheduler parameters
+lr_scheduler: "cosine"
+warmup_proportion: 0
+
+# Validation and checkpoint saving parameters
+validations_per_epoch: 1
+validate_after_epoch: false
+validate_on_end: false
+save_on_end: false
+save_on_validate: false
+
+
+# Distributed_strategy
+parallelization_strategy: "fsdp"
+
+# FSDP specific parameters
+auto_wrap_policy: "llama"
+sharding_strategy: "FULL_SHARD"
+state_dict_type: "sharded"
+limit_all_gathers: true
+cpu_offload: false
+num_workers: 4
+gradient_checkpointing: true
+
+# Wandb logging specific parameters
+logging_config: wandb
+wandb_project: "lmtk-benchmark-2"
+wandb_entity: "gplsi_continual"
+wandb_run_name: "llama3_2-3b-bench-continual-7gpu-prueba-batch6"
+log_model: false
+log_iter_interval: 10
+
+
+seed: 42

--- a/config/experiments/salamandra-2b-bench/salamandra-2b-bench.yaml
+++ b/config/experiments/salamandra-2b-bench/salamandra-2b-bench.yaml
@@ -1,0 +1,76 @@
+task: "clm_training"
+experiment_name: "salamandra-2b-bench-continual"
+verbose_level: 3
+
+# Training data
+dataset:
+  source: "local"
+  nameOrPath: "/workspace/data/tokenized/anonymized-va-bench"
+  format: "hf"
+
+# Output dir
+output_dir: "output/salamandra-2b-bench/"
+precision: "bf16-true"
+
+# Model
+model_name: "BSC-LT/salamandra-2b"
+
+
+static_graph: false
+
+# Training parameters
+number_epochs: 1
+batch_size: 3
+
+# Validation parameters
+validations_per_epoch: 1
+
+# Gradient parameters
+gradient_accumulation: true
+gradient_accumulation_steps: 4
+grad_clip: 1.0
+
+# Optimizer parameters
+lr: 0.00002
+lr_decay: true
+weight_decay: 0.01
+beta1: 0.9
+beta2: 0.999
+
+# Scheduler parameters
+lr_scheduler: "cosine"
+warmup_proportion: 0
+
+# Validation and checkpoint saving parameters
+validations_per_epoch: 1
+validate_after_epoch: false
+validate_on_end: false
+save_on_end: false
+save_on_validate: false
+
+# Logging
+logging_config: "wandb"
+
+# Wandb logging specific parameters
+wandb_project: "lmtk-benchmark-2"
+wandb_entity: "gplsi_continual"
+wandb_run_name: "salamandra-2b-bench-continual-4gpu-4batch"
+log_model: false
+log_iter_interval: 10
+
+# Distributed strategy
+parallelization_strategy: "fsdp"
+
+# FSDP specific parameters
+auto_wrap_policy: "llama"
+sharding_strategy: "FULL_SHARD"
+state_dict_type: "sharded"
+limit_all_gathers: true
+cpu_offload: false
+num_workers: 4
+gradient_checkpointing: true
+
+
+seed: 42
+
+

--- a/config/experiments/salamandra-2b-bench/salamandra_2b_mini_bench.yaml
+++ b/config/experiments/salamandra-2b-bench/salamandra_2b_mini_bench.yaml
@@ -1,0 +1,70 @@
+task: "clm_training"
+experiment_name: "llama3.2-3b-bench-continual"
+verbose_level: 3
+
+# Training data
+dataset:
+  source: "local"
+  nameOrPath: "/workspace/data/tokenized/dc6-salamandra-2b"
+  #nameOrPath: "/workspace/data/tokenized/anonymized-va-bench"
+  format: "hf"
+
+# Output dir
+output_dir: "output/salamadnra-2b-test_llama-bench/"
+precision: "bf16-true"
+# Model
+model_name: "BSC-LT/salamandra-2b"
+#"meta-llama/Llama-3.2-3B"
+
+# Model precision
+static_graph: false
+
+# Training parameters
+number_epochs: 1
+batch_size: 4
+gradient_accumulation: true
+gradient_accumulation_steps: 4
+grad_clip: 1.0
+
+# Optimizer parameters
+lr: 0.00002      
+lr_decay: true
+weight_decay: 0.01
+beta1: 0.9
+beta2: 0.999
+
+
+# Scheduler parameters
+lr_scheduler: "cosine"
+warmup_proportion: 0
+
+# Validation and checkpoint saving parameters
+validations_per_epoch: 1
+validate_after_epoch: false
+validate_on_end: false
+save_on_end: false
+save_on_validate: false
+
+
+# Distributed_strategy
+parallelization_strategy: "fsdp"
+
+# FSDP specific parameters
+auto_wrap_policy: "llama"
+sharding_strategy: "FULL_SHARD"
+state_dict_type: "sharded"
+limit_all_gathers: true
+cpu_offload: false
+num_workers: 4
+gradient_checkpointing: true
+
+# Wandb logging specific parameters
+logging_config: wandb
+wandb_project: "lmtk-benchmark-2"
+wandb_entity: "gplsi_continual"
+wandb_run_name: "salamandra2b-bench-continual-8gpu-prueba-batch4"
+log_model: false
+log_iter_interval: 10
+
+
+seed: 42

--- a/config/experiments/salamandra-2b-bench/tokenizer.yaml
+++ b/config/experiments/salamandra-2b-bench/tokenizer.yaml
@@ -1,0 +1,23 @@
+task: "tokenization"
+experiment_name: "md_anonymized_llama_3b_tokenization"
+verbose_level: 3
+
+tokenizer:
+  tokenizer_name: "meta-llama/Llama-3.2-3B"
+  context_length: 2048
+  overlap: 512
+  task: "clm_training"
+
+dataset:
+  source: "local"
+  nameOrPath: "/workspace/data/dc6"
+  format: "files"
+  file_config:
+    text_key: "text"
+    format: "txt"
+    encoding: "utf-8"
+
+output:
+  path: "/workspace/data/tokenized/dc6-llama-3b"
+
+test_size: 0.9

--- a/config/experiments/salamandra-2b-bench/tokenizer_salamandra.yaml
+++ b/config/experiments/salamandra-2b-bench/tokenizer_salamandra.yaml
@@ -1,0 +1,23 @@
+task: "tokenization"
+experiment_name: "md_anonymized_llama_3b_tokenization"
+verbose_level: 3
+
+tokenizer:
+  tokenizer_name: "BSC-LT/salamandra-2b"
+  context_length: 2048
+  overlap: 512
+  task: "clm_training"
+
+dataset:
+  source: "local"
+  nameOrPath: "/workspace/data/dc6"
+  format: "files"
+  file_config:
+    text_key: "text"
+    format: "txt"
+    encoding: "utf-8"
+
+output:
+  path: "/workspace/data/tokenized/dc6-salamandra-2b"
+
+test_size: 0.9

--- a/src/tasks/tokenization/orchestrator.py
+++ b/src/tasks/tokenization/orchestrator.py
@@ -65,7 +65,15 @@ class TokenizationOrchestrator(BaseOrchestrator):
         Returns:
             HFDataset: The tokenized version of the input dataset.
         """        
-        context_length = self.config.tokenizer.max_sequence_length
+        context_length = getattr(
+            self.config.tokenizer,
+            "max_sequence_length",
+            getattr(self.config.tokenizer, "context_length", None),
+        )
+        if context_length is None:
+            raise ValueError(
+                "Tokenizer configuration must define either max_sequence_length or context_length"
+            )
         overlap = self.config.tokenizer.get("overlap")
         tokenizer_name = self.config.tokenizer.tokenizer_name
         batch_size = self.config.tokenizer.get("batch_size", 2000)  # Default batch size if not specified

--- a/src/tasks/training/fabric/model/base.py
+++ b/src/tasks/training/fabric/model/base.py
@@ -87,16 +87,23 @@ class BaseModel(L.LightningModule):
             dict: Contains the computed 'loss' and model 'outputs'.
         """
 
-        # Validate batch and model (only on debug level)
         if self.cli_logger.getEffectiveLevel() == logging.DEBUG:
             self._batch_validation(batch, "train")
             self._model_validation()
         
-        outputs = self.model(
-            input_ids=batch['input_ids'],
-            attention_mask=batch['attention_mask'],
-            labels=batch['labels'],
-        )
+        if self.torch_dtype in (torch.bfloat16, torch.float16):
+            with torch.autocast(device_type="cuda", dtype=self.torch_dtype):
+                outputs = self.model(
+                    input_ids=batch['input_ids'],
+                    attention_mask=batch['attention_mask'],
+                    labels=batch['labels'],
+                )
+        else:
+            outputs = self.model(
+                input_ids=batch['input_ids'],
+                attention_mask=batch['attention_mask'],
+                labels=batch['labels'],
+            )
         
         # Log training metrics periodically
         if hasattr(self, 'global_step') and self.global_step % 5 == 0:
@@ -128,11 +135,19 @@ class BaseModel(L.LightningModule):
             self._batch_validation(batch, "validation")
             self._model_validation()
 
-        outputs = self.model(
-            input_ids=batch['input_ids'],
-            attention_mask=batch['attention_mask'],
-            labels=batch['labels']
-        )
+        if self.torch_dtype in (torch.bfloat16, torch.float16):
+            with torch.autocast(device_type="cuda", dtype=self.torch_dtype):
+                outputs = self.model(
+                    input_ids=batch['input_ids'],
+                    attention_mask=batch['attention_mask'],
+                    labels=batch['labels']
+                )
+        else:
+            outputs = self.model(
+                input_ids=batch['input_ids'],
+                attention_mask=batch['attention_mask'],
+                labels=batch['labels']
+            )
         
         # Log validation metrics periodically
         if hasattr(self, 'global_step') and self.global_step % 5 == 0:
@@ -164,11 +179,19 @@ class BaseModel(L.LightningModule):
             self._model_validation()
 
 
-        outputs = self.model(
-            batch['input_ids'],
-            batch['attention_mask'],
-            labels=batch['labels'],
-        )
+        if self.torch_dtype in (torch.bfloat16, torch.float16):
+            with torch.autocast(device_type="cuda", dtype=self.torch_dtype):
+                outputs = self.model(
+                    batch['input_ids'],
+                    batch['attention_mask'],
+                    labels=batch['labels'],
+                )
+        else:
+            outputs = self.model(
+                batch['input_ids'],
+                batch['attention_mask'],
+                labels=batch['labels'],
+            )
         
         # Log test metrics periodically
         if hasattr(self, 'global_step') and self.global_step % 5 == 0:

--- a/src/tasks/training/fabric/trainer/base.py
+++ b/src/tasks/training/fabric/trainer/base.py
@@ -770,9 +770,9 @@ class FabricTrainerBase(ABC):
 
         # GRADIENT CHECKPOINTING
         if self.config.gradient_checkpointing:
-            self.model.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={
-                "use_reentrant": False
-            })
+            self.model.model.gradient_checkpointing_enable(
+                gradient_checkpointing_kwargs={"use_reentrant": False}
+            )
         else:
             self.model.model.gradient_checkpointing_disable()
 

--- a/src/tasks/training/fabric/trainer/base.py
+++ b/src/tasks/training/fabric/trainer/base.py
@@ -767,7 +767,7 @@ class FabricTrainerBase(ABC):
             
             # Properly set up the model with fabric for FSDP
             self.model = fabric.setup(self.model)
-
+            self.cli_logger.info(f"Time to SetUP model: {time.perf_counter() - t0:.02f} seconds.")
         # GRADIENT CHECKPOINTING
         if self.config.gradient_checkpointing:
             self.model.model.gradient_checkpointing_enable(

--- a/src/tasks/training/fabric/trainer/distributed.py
+++ b/src/tasks/training/fabric/trainer/distributed.py
@@ -60,16 +60,15 @@ class FSDP(FabricTrainerBase):
             self.strategy = FSDPStrategy(
                 sharding_strategy=fsdp_config["sharding_strategy"],
                 auto_wrap_policy=policy,#auto_wrap_policy=fsdp_config["auto_wrap_policy"],
-            state_dict_type=fsdp_config["state_dict_type"],
+                state_dict_type=fsdp_config["state_dict_type"],
                 limit_all_gathers=fsdp_config["limit_all_gathers"],
                 cpu_offload=fsdp_config["cpu_offload"],
-                mixed_precision=fsdp_config["mixed_precision"],
                 backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
                 forward_prefetch=False,  # Deshabilitar para evitar conflictos con checkpointing
                 use_orig_params=True,    # Importante para compatibilidad con gradient checkpointing
                 sync_module_states=True, # Asegurar sincronización entre ranks
                                 #activation_checkpointing_policy=policy,#activation_checkpointing_policy=fsdp_config["activation_checkpointing"],#activation_checkpointing=fsdp_config["activation_checkpointing"] is deprecated,
-                
+                #mixed_precision=fsdp_config["mixed_precision"],
                 
             )
             

--- a/src/tasks/training/fabric/trainer/distributed.py
+++ b/src/tasks/training/fabric/trainer/distributed.py
@@ -20,7 +20,7 @@ from src.tasks.training.fabric.trainer.base import FabricTrainerBase
 from src.tasks.training.fabric.wrappers.fsdp_config import resolve_fsdp_config
 from utils import inherit_init_params
 from src.tasks.training.fabric.speed_monitor import SpeedMonitorFabric as Monitor
-
+from torch.distributed.fsdp import BackwardPrefetch
 
 @inherit_init_params
 class FSDP(FabricTrainerBase):
@@ -60,13 +60,20 @@ class FSDP(FabricTrainerBase):
             self.strategy = FSDPStrategy(
                 sharding_strategy=fsdp_config["sharding_strategy"],
                 auto_wrap_policy=policy,#auto_wrap_policy=fsdp_config["auto_wrap_policy"],
-                activation_checkpointing_policy=policy,#activation_checkpointing_policy=fsdp_config["activation_checkpointing"],#activation_checkpointing=fsdp_config["activation_checkpointing"] is deprecated,
-                state_dict_type=fsdp_config["state_dict_type"],
+            state_dict_type=fsdp_config["state_dict_type"],
                 limit_all_gathers=fsdp_config["limit_all_gathers"],
                 cpu_offload=fsdp_config["cpu_offload"],
+                mixed_precision=fsdp_config["mixed_precision"],
+                backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+                forward_prefetch=False,  # Deshabilitar para evitar conflictos con checkpointing
+                use_orig_params=True,    # Importante para compatibilidad con gradient checkpointing
+                sync_module_states=True, # Asegurar sincronización entre ranks
+                                #activation_checkpointing_policy=policy,#activation_checkpointing_policy=fsdp_config["activation_checkpointing"],#activation_checkpointing=fsdp_config["activation_checkpointing"] is deprecated,
+                
                 
             )
             
+            self.cli_logger.info(f"Strategy : {self.strategy}")
             #self.cli_logger.info(f"Using auto_wrap_policy: {fsdp_config['auto_wrap_policy']}")
             self.cli_logger.info(f"Using auto_wrap_policy: {policy}")
             if fsdp_config["activation_checkpointing"]:

--- a/src/tasks/training/fabric/wrappers/fsdp_config.py
+++ b/src/tasks/training/fabric/wrappers/fsdp_config.py
@@ -5,7 +5,8 @@ from typing import Optional, Dict, Any, Set, Type, Union, Callable
 import torch.nn as nn
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy, size_based_auto_wrap_policy
 from src.tasks.training.fabric.wrappers.policies import create_auto_wrap_policy
-
+from torch.distributed.fsdp import MixedPrecision
+import torch
 def get_default_fsdp_config() -> Dict[str, Any]:
     """
     Return the default configuration for Fully Sharded Data Parallel (FSDP) strategy.
@@ -68,8 +69,30 @@ def resolve_fsdp_config(config: Dict[str, Any], model_name: str) -> Dict[str, An
             # Here we create a policy dictionary for those layers.
             layer_cls = fsdp_config["auto_wrap_policy"].keywords["transformer_layer_cls"]
             fsdp_config["activation_checkpointing_policy"] = {layer_cls: dict()}
-    
 
+    # TODO: check without this
+    #precision = config.get("precision", "32-true")
+    #if precision in ["bf16-true", "bf16-mixed", "bf16"]:
+    #        fsdp_config["mixed_precision"] = MixedPrecision(
+    #            param_dtype=torch.bfloat16,
+    #            reduce_dtype=torch.bfloat16,
+    #            buffer_dtype=torch.bfloat16,
+    #            cast_forward_inputs=True,     
+    #            cast_root_forward_inputs=True,
+    #        )
+    #elif precision in ["16-true", "16-mixed", "16"]:
+    #    fsdp_config["mixed_precision"] = MixedPrecision(
+    #        param_dtype=torch.float16,
+    #        reduce_dtype=torch.float16,
+    #        buffer_dtype=torch.float16,
+    #        cast_forward_inputs=True,
+    #        cast_root_forward_inputs=True,
+    #    )
+    #else:
+    #    fsdp_config["mixed_precision"] = None
+
+    #print(fsdp_config)
+    
     return fsdp_config
 
 

--- a/src/utils/dataset/storage.py
+++ b/src/utils/dataset/storage.py
@@ -145,7 +145,7 @@ class DatasetStorage:
                         for i, line in enumerate(f):
                             try:
                                 json_obj = json.loads(line.strip())
-                                self.__process_json_entry(json_obj, data, file_path, i)
+                                self._process_json_entry(json_obj, data, file_path, i)
                             except json.JSONDecodeError:
                                 self.logger.error(f"Error parsing JSON at line {i+1} in {file_path}: Invalid JSON format")
                     else:


### PR DESCRIPTION
Hemos arreglado un problema encotrado en el gradient checkpointing donde se recalculan las activaciones en una precisión mayor lo que provoca un error al comparar los elementos en diferentes precisiones. Para arreglarlo de forma consistente hemos hecho un wrapper alrededor del modelo que asegura que en caso de recomputar estos parámetros siempre se realizan en la precisión indicada en el archivo de configuración.

También hemos arreglado algunos métodos que se llamaban de forma errónea así como el nombre de algunos parámetros que han cambiado.